### PR TITLE
Fix documentation and contact links

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Here's a link to the [npm](https://npmjs.org/package/dotty) page.
 
 ## Usage
 
-Also see the [documentation](http://deoxxa.github.com/dotty/docs/) and
+Also see the [documentation](http://deoxxa.github.io/dotty/docs/) and
 [example](example.js).
 
 ```javascript
@@ -74,6 +74,6 @@ console.log(object);
 
 ## Contact
 
-- GitHub ([http://github.com/deoxxa](deoxxa))
-- Twitter ([http://twitter.com/deoxxa](@deoxxa))
-- Email ([mailto:deoxxa@fknsrs.biz](deoxxa@fknsrs.biz))
+- GitHub ([deoxxa](https://github.com/deoxxa))
+- Twitter ([@deoxxa](https://twitter.com/deoxxa))
+- Email ([deoxxa@fknsrs.biz](mailto:deoxxa@fknsrs.biz))

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Here's a link to the [npm](https://npmjs.org/package/dotty) page.
 
 ## Usage
 
-Also see the [documentation](http://deoxxa.github.io/dotty/docs/) and
+Also see the [documentation](https://deoxxa.github.io/dotty/docs/) and
 [example](example.js).
 
 ```javascript


### PR DESCRIPTION
Update documentation link to use github.io, fix markdown for contact links (addresses #35)